### PR TITLE
Change redis persistent volume path to /data

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,7 +97,7 @@ services:
     # ports:
     #   - 6379:6379
     volumes:
-      - ./redis_data:/var/lib/redis
+      - ./redis_data:/data
     #  - ./redis/redis.conf:/usr/local/etc/redis/redis.conf
     environment:
       - REDIS_REPLICATION_MODE=master

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,7 +93,7 @@ services:
     hostname: redis
     networks:
       - internal
-    command: redis-server --save 60 1 --loglevel notice --requirepass ${REDIS_PASSWORD}
+    command: redis-server --save 60 1 --loglevel warning --requirepass ${REDIS_PASSWORD}
     # ports:
     #   - 6379:6379
     volumes:


### PR DESCRIPTION
The existing redis data path was incorrect. Use /data, where redis stores the persisted data.